### PR TITLE
Generate documentation via Sphinx

### DIFF
--- a/.github/workflows/gh-pages-deployment.yml
+++ b/.github/workflows/gh-pages-deployment.yml
@@ -20,8 +20,35 @@ jobs:
         hugo-version: '0.109.0'
         extended: true
 
-    - name: Build                                
+    - name: Build site
       run: hugo
+
+    - name: Checkout hiperwalk source code
+      uses: actions/checkout@v3
+      with:
+        repository: hiperwalk/hiperwalk
+        path: hiperwalk
+        ref: 2.0.x
+
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Build docs
+      run: |
+          pushd hiperwalk/docs/
+          pip3 install -r requirements.txt
+          ./go
+          popd
+
+    - name: Copy Sphinx generated HTML files
+      run: |
+          mkdir -p ./public/doc
+          cp -r hiperwalk/docs/build/html/* ./public/doc
+
+    - name: Prevent Jekyll processing
+      run: touch ./public/.nojekyll
 
     - name: Deploy                               
       uses: peaceiris/actions-gh-pages@v2

--- a/config.yaml
+++ b/config.yaml
@@ -26,8 +26,7 @@ params:
     - title: Get started
       url: /getstarted/
     - title: Documentation
-      url: https://hiperwalk.readthedocs.io/en/stable/
-      is_external: true
+      url: /doc/
     - title: Shortcodes
       url: /shortcodes/
   keyfeatures:


### PR DESCRIPTION
This PR changes the page generation workflow.

The GitHub Action runner now checks out the branch [2.0.x](https://github.com/hiperwalk/hiperwalk/tree/2.0.x) of the [hiperwalk](https://github.com/hiperwalk/hiperwalk) code, generates the documentation with Sphinx and copies the generated HTML files and assets to `/doc/`.

:warning: Some of the directories generated by Sphinx have names that start with `_`. It was required to configure GitHub Pages to skip Jekyll processing. Read more [here](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/).